### PR TITLE
Update usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ workflow "Add label to PR" {
   resolves = "PR Labeler"
 }
 
+action "PR opened filter" {
+  uses = "actions/bin/filter@master"
+  args = "action opened"
+}
+
 action "PR Labeler" {
+  needs = "PR opened filter"
   uses = "TimonVS/pr-labeler@master"
   secrets = ["GITHUB_TOKEN"]
 }


### PR DESCRIPTION
Update usage example to include a filter that only passes through `pull_requests.opened` events to PR Labeler.

Solves #1 