### PR TITLE
replace deprecated wildcard with matcher and update readme with new YAML configuration format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,24 +5,19 @@ Can be used in combination with [Release Drafter](https://github.com/toolmantim/
 
 ## Usage
 
-Add `.github/main.workflow` with the following:
+Add `.github/workflows/pr-labeler.yml` with the following:
 
-```
-workflow "Add label to PR" {
-  on = "pull_request"
-  resolves = "PR Labeler"
-}
-
-action "PR opened filter" {
-  uses = "actions/bin/filter@master"
-  args = "action opened"
-}
-
-action "PR Labeler" {
-  needs = "PR opened filter"
-  uses = "TimonVS/pr-labeler@master"
-  secrets = ["GITHUB_TOKEN"]
-}
+```yml
+name: Label PRs
+on: [pull_request]
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler@master
+        if: github.event.action == 'opened'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Configuration
@@ -35,6 +30,11 @@ For example:
 feature: ['feature/*', 'feat/*']
 fix: fix/*
 chore: chore/*
+fixed-branch: fixed-branch-name
 ```
 
 Then if a pull request is opened with the branch name `feature/218-add-emoji-support` the Action will automatically apply the `feature` label.
+
+### Wildcard branches in configuration
+
+You can use `*` as a wildcard for matching multiple branch names. See https://www.npmjs.com/package/matcher for more information about wildcard options.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { Toolkit } = require('actions-toolkit')
 const getConfig = require('./utils/config')
-const wildcard = require('wildcard')
+const matcher = require('matcher')
 
 const CONFIG_FILENAME = 'pr-labeler.yml'
 const defaults = {
@@ -25,8 +25,8 @@ Toolkit.run(
       (labels, [label, patterns]) => {
         if (
           Array.isArray(patterns)
-            ? patterns.some(pattern => wildcard(pattern, ref))
-            : wildcard(patterns, ref)
+            ? patterns.some(pattern => matcher.isMatch(ref, pattern))
+            : matcher.isMatch(ref, patterns)
         ) {
           labels.push(label)
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,8 +1771,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1793,14 +1792,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1815,20 +1812,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1945,8 +1939,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1958,7 +1951,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1973,7 +1965,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1981,14 +1972,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2007,7 +1996,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2088,8 +2076,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2101,7 +2088,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2187,8 +2173,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2224,7 +2209,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2244,7 +2228,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2288,14 +2271,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3486,6 +3467,21 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "matcher": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+      "integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        }
       }
     },
     "mem": {
@@ -5192,11 +5188,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "wildcard": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-1.1.2.tgz",
-      "integrity": "sha1-pwIEUwhNjNLv5wup02liY94XEKU="
     },
     "windows-release": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "actions-toolkit": "^2.0.0",
-    "wildcard": "^1.1.2"
+    "matcher": "^2.0.0"
   },
   "devDependencies": {
     "jest": "^24.5.0",


### PR DESCRIPTION
I managed to get this action working in the new YAML format. Through debugging I found some issues in the _wildcard_ dependency therefore I decided to replace it with the _official_ recommended replacement: _matcher_.

**Changelog**
- replace deprecated wildcard dependency with matcher (fixes #5)
> Work on this project is largely inactive, now so I'd recommend checking out the wonderful matcher package as a solid alternative.
https://www.npmjs.com/package/wildcard

- updated configuration (readme) for YAML format (credit to @roni-frantchi #5) 

Hope you (and others) find it useful. If you (@TimonVS) like we can talk about sharing this little project. I would be willing to volunteer as a maintainer since I find this useful and will be using it in some projects. 