### PR TITLE
load pr-labeler config from branch initiating the pull request

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,12 @@ Toolkit.run(
   async tools => {
     const repoInfo = {
       owner: tools.context.payload.repository.owner.login,
-      repo: tools.context.payload.repository.name
+      repo: tools.context.payload.repository.name,
     }
     const ref = tools.context.payload.pull_request.head.ref
     const config = {
       ...defaults,
-      ...(await getConfig(tools.github, CONFIG_FILENAME, repoInfo))
+      ...(await getConfig(tools.github, CONFIG_FILENAME, repoInfo, ref))
     }
 
     const labelsToAdd = Object.entries(config).reduce(

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ Toolkit.run(
   async tools => {
     const repoInfo = {
       owner: tools.context.payload.repository.owner.login,
-      repo: tools.context.payload.repository.name,
+      repo: tools.context.payload.repository.name
     }
     const ref = tools.context.payload.pull_request.head.ref
     const config = {

--- a/utils/config.js
+++ b/utils/config.js
@@ -6,12 +6,13 @@ const CONFIG_PATH = '.github'
 /**
  * @returns {Promise<Object.<string, string | string[]>>}
  */
-module.exports = async function getConfig(github, fileName, { owner, repo }) {
+module.exports = async function getConfig(github, fileName, { owner, repo }, ref) {
   try {
     const response = await github.repos.getContents({
       owner,
       repo,
-      path: path.posix.join(CONFIG_PATH, fileName)
+      path: path.posix.join(CONFIG_PATH, fileName),
+      ref: ref
     })
 
     return parseConfig(response.data.content)


### PR DESCRIPTION
as described in #6 this change will load the pr-labeler config (.github/pr-labeler.yml) from the branch which initiates the pull request and not from the master branch.