### PR TITLE
Allow negative patterns to be used in an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ For example:
 feature: ['feature/*', 'feat/*']
 fix: fix/*
 chore: chore/*
-fixed-branch: fixed-branch-name
 ```
 
 Then if a pull request is opened with the branch name `feature/218-add-emoji-support` the Action will automatically apply the `feature` label.
@@ -44,21 +43,6 @@ Then if a pull request is opened with the branch name `feature/218-add-emoji-sup
 ### Wildcard branches in configuration
 
 You can use `*` as a wildcard for matching multiple branch names. See https://www.npmjs.com/package/matcher for more information about wildcard options.
-
-### Negative matcher
-
-You can also use `!` to add a label on all branches that does NOT match the pattern.
-
-Used in a list of patterns, then, the branch name will have to match all patterns.
-
-For example:
-
-```yml
-patch: ['update/*', '!update/sbt-*']
-no-release: update/sbt-*
-```
-
-In this scenario, a branch named `update/sbt-native-package` will only have the `no-release` label
 
 ### Default configuration
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ Then if a pull request is opened with the branch name `feature/218-add-emoji-sup
 
 You can use `*` as a wildcard for matching multiple branch names. See https://www.npmjs.com/package/matcher for more information about wildcard options.
 
+### Negative matcher
+
+You can also use `!` to add a label on all branches that does NOT match the pattern.
+
+Used in a list of patterns, then, the branch name will have to match all patterns.
+
+For example:
+
+```yml
+patch: ['update/*', '!update/sbt-*']
+no-release: update/sbt-*
+```
+
+In this scenario, a branch named `update/sbt-native-package` will only have the `no-release` label
+
 ### Default configuration
 
 When no configuration is provided, the following defaults will be used:

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -76,6 +76,22 @@ describe('pr-labeler-action', () => {
     expect.assertions(1)
   })
 
+  it("adds only one label if the branch matches a negative pattern", async () => {
+    nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=release%2Fskip-this-one')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', body => {
+          expect(body).toMatchObject({
+            labels: ['skip-release']
+          })
+          return true
+        })
+        .reply(200)
+
+    await action(new MockContext(pullRequestOpenedFixture({ ref: 'release/skip-this-one' })))
+    expect.assertions(1)
+  })
+
   it("adds no labels if the branch doesn't match any patterns", async () => {
     nock('https://api.github.com')
       .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=hello_world')

--- a/__tests__/fixtures/config.yml
+++ b/__tests__/fixtures/config.yml
@@ -1,4 +1,5 @@
 '🎉 feature': ['feature/*', 'feat/*']
 fix: fix/*
 chore: chore/*
-release: release/*
+release: ['release/*', '!release/skip-*']
+skip-release: release/skip-*

--- a/__tests__/fixtures/config.yml
+++ b/__tests__/fixtures/config.yml
@@ -1,5 +1,5 @@
 '🎉 feature': ['feature/*', 'feat/*']
 fix: fix/*
 chore: chore/*
-release: ['release/*', '!release/skip-*']
+release: ['release/*', 'hotfix/*', '!release/skip-*']
 skip-release: release/skip-*

--- a/src/action.ts
+++ b/src/action.ts
@@ -45,11 +45,14 @@ async function action(context: Context = github.context) {
 
 function getLabelsToAdd(config: Config, branchName: string): string[] {
   return Object.entries(config).reduce(
-    (labels, [label, patterns]) => {
+
+    (labels, [label, pattern]) => {
+      const patterns = Array.isArray(pattern) ? pattern : [pattern]
+
       if (
-        Array.isArray(patterns)
-          ? patterns.some(pattern => matcher.isMatch(branchName, pattern))
-          : matcher.isMatch(branchName, patterns)
+        patterns.some(pattern => pattern.startsWith("!"))
+            ? patterns.every(pattern => matcher.isMatch(branchName, pattern))
+            : patterns.some(pattern => matcher.isMatch(branchName, pattern))
       ) {
         labels.push(label)
       }

--- a/src/utils/arrayify.ts
+++ b/src/utils/arrayify.ts
@@ -1,0 +1,3 @@
+export function arrayify<T>(x: T | T[]): T[] {
+  return Array.isArray(x) ? x : [x]
+}


### PR DESCRIPTION
After using `pr-labeler-action` for a while, I wanted to be able to leverage the negative matcher as shown in the `matcher` documentation: https://www.npmjs.com/package/matcher#usage

Specifically what is shown in the first example:

```
matcher(['foo', 'bar', 'moo'], ['*oo', '!foo']);
//=> ['moo']
```

This PR propose that, when using a negative matcher in a list of patterns, the following example is viable and will only add one label for `update/sbt-native-packager`

```yml
patch: ['update/*', '!update/sbt-*']
no-release: update/sbt-*
``` 

The original behaviour is unchanged