### PR TITLE
fix: upgrade GitHub Action to use Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ branding:
   icon: 'tag'
   color: 'white'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
See as well https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/