### PR TITLE
add a new feature of require labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ jobs:
       - uses: TimonVS/pr-labeler-action@v3
         with:
           configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
+          require-labeling: true # optional, false is the default value. Github Action fails if none of labels defined in config yml is matched nor manually assigned
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core';
 import nock from 'nock';
 import fs from 'fs';
 import path from 'path';
@@ -8,100 +9,133 @@ import { WebhookPayload } from '@actions/github/lib/interfaces';
 nock.disableNetConnect();
 
 describe('pr-labeler-action', () => {
-  beforeEach(() => {
-    setupEnvironmentVariables();
+  describe("requireLabeling is 'false'", () => {
+    beforeEach(() => {
+      setupEnvironmentVariables("false");
+    });
+
+    it('adds the "fix" label for "fix/510-logging" branch', async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=fix%2F510-logging')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          expect(body).toMatchObject({
+            labels: ['fix'],
+          });
+          return true;
+        })
+        .reply(200);
+
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'fix/510-logging' })));
+      expect.assertions(1);
+    });
+
+    it('adds the "feature" label for "feature/sign-in-page/101" branch', async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=feature%2Fsign-in-page%2F101')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          expect(body).toMatchObject({
+            labels: ['🎉 feature'],
+          });
+          return true;
+        })
+        .reply(200);
+
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'feature/sign-in-page/101' })));
+      expect.assertions(1);
+    });
+
+    it('adds the "release" label for "release/2.0" branch', async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=release%2F2.0')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          expect(body).toMatchObject({
+            labels: ['release'],
+          });
+          return true;
+        })
+        .reply(200);
+  
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'release/2.0' })));
+      expect.assertions(1);
+    });
+
+    it('uses the default config when no config was provided', async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=fix%2F510-logging')
+        .reply(404)
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          expect(body).toMatchObject({
+            labels: ['fix'],
+          });
+          return true;
+        })
+        .reply(200);
+
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'fix/510-logging' })));
+      expect.assertions(1);
+    });
+
+    it('adds only one label if the branch matches a negative pattern', async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=release%2Fskip-this-one')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          expect(body).toMatchObject({
+            labels: ['skip-release'],
+          });
+          return true;
+        })
+        .reply(200);
+
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'release/skip-this-one' })));
+      expect.assertions(1);
+    });
+
+    it("adds no labels if the branch doesn't match any patterns", async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=hello_world')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          throw new Error("Shouldn't edit labels");
+        })
+        .reply(200);
+
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'hello_world' })));
+    });
   });
+  describe("requireLabeling is 'true'", () => {
+    const spy = jest.spyOn(core, 'setFailed');
+    beforeEach(() => {
+      setupEnvironmentVariables("true");
+    });
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
 
-  it('adds the "fix" label for "fix/510-logging" branch', async () => {
-    nock('https://api.github.com')
-      .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=fix%2F510-logging')
-      .reply(200, configFixture())
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
-        expect(body).toMatchObject({
-          labels: ['fix'],
-        });
-        return true;
-      })
-      .reply(200);
+    it("fail if none of expected labels is assigned AND requireLabeling is 'true'", async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=require_labeling')
+        .reply(200, configFixture())
+        .get('/repos/Codertocat/Hello-World/issues/1/labels')
+        .reply(200, pullRequestLabelsFixture('require_labeling')); // not expected label
 
-    await action(new MockContext(pullRequestOpenedFixture({ ref: 'fix/510-logging' })));
-    expect.assertions(1);
-  });
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'require_labeling' })));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
 
-  it('adds the "feature" label for "feature/sign-in-page/101" branch', async () => {
-    nock('https://api.github.com')
-      .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=feature%2Fsign-in-page%2F101')
-      .reply(200, configFixture())
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
-        expect(body).toMatchObject({
-          labels: ['🎉 feature'],
-        });
-        return true;
-      })
-      .reply(200);
+    it("no label is added but the result is success", async () => {
+      nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=require_labeling')
+        .reply(200, configFixture())
+        .get('/repos/Codertocat/Hello-World/issues/1/labels')
+        .reply(200, pullRequestLabelsFixture('fix')); // one of expected labels is manually assigned
 
-    await action(new MockContext(pullRequestOpenedFixture({ ref: 'feature/sign-in-page/101' })));
-    expect.assertions(1);
-  });
-
-  it('adds the "release" label for "release/2.0" branch', async () => {
-    nock('https://api.github.com')
-      .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=release%2F2.0')
-      .reply(200, configFixture())
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
-        expect(body).toMatchObject({
-          labels: ['release'],
-        });
-        return true;
-      })
-      .reply(200);
-
-    await action(new MockContext(pullRequestOpenedFixture({ ref: 'release/2.0' })));
-    expect.assertions(1);
-  });
-
-  it('uses the default config when no config was provided', async () => {
-    nock('https://api.github.com')
-      .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=fix%2F510-logging')
-      .reply(404)
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
-        expect(body).toMatchObject({
-          labels: ['fix'],
-        });
-        return true;
-      })
-      .reply(200);
-
-    await action(new MockContext(pullRequestOpenedFixture({ ref: 'fix/510-logging' })));
-    expect.assertions(1);
-  });
-
-  it('adds only one label if the branch matches a negative pattern', async () => {
-    nock('https://api.github.com')
-      .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=release%2Fskip-this-one')
-      .reply(200, configFixture())
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
-        expect(body).toMatchObject({
-          labels: ['skip-release'],
-        });
-        return true;
-      })
-      .reply(200);
-
-    await action(new MockContext(pullRequestOpenedFixture({ ref: 'release/skip-this-one' })));
-    expect.assertions(1);
-  });
-
-  it("adds no labels if the branch doesn't match any patterns", async () => {
-    nock('https://api.github.com')
-      .get('/repos/Codertocat/Hello-World/contents/.github/pr-labeler.yml?ref=hello_world')
-      .reply(200, configFixture())
-      .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
-        throw new Error("Shouldn't edit labels");
-      })
-      .reply(200);
-
-    await action(new MockContext(pullRequestOpenedFixture({ ref: 'hello_world' })));
+      await action(new MockContext(pullRequestOpenedFixture({ ref: 'require_labeling' })));
+      expect(spy).toHaveBeenCalledTimes(0);
+    });
   });
 });
 
@@ -154,11 +188,28 @@ function pullRequestOpenedFixture({ ref }: { ref: string }) {
   };
 }
 
-function setupEnvironmentVariables() {
+function pullRequestLabelsFixture(labelName: string) {
+  // https://docs.github.com/ja/rest/issues/labels#list-labels-for-an-issue
+  return [
+    {
+      "id": 208045946,
+      "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+      "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+      "name": labelName,
+      "description": "Something isn't working",
+      "color": "f29513",
+      "default": true
+    }
+  ];
+}
+
+
+function setupEnvironmentVariables(requireLabeling: string) {
   // reset process.env otherwise `Context` will use those variables
   process.env = {};
 
   // configuration-path parameter is required
   // parameters are exposed as environment variables: https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepswith
   process.env['INPUT_CONFIGURATION-PATH'] = '.github/pr-labeler.yml';
+  process.env['INPUT_REQUIRE-LABELING'] = requireLabeling;
 }

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   configuration-path:
     description: 'The path for the label configurations'
     default: '.github/pr-labeler.yml'
+  require-labeling:
+    description: 'true means at least 1 labeling rule needs to be matched'
+    default: 'false'
 branding:
   icon: 'tag'
   color: 'white'


### PR DESCRIPTION
# What
I added a feature of "require labeling"
if none of expected labels is matched nor manually attached, this Github Action will fail when require-labeling is true.

# Why

I need all PRs to have one of expected labels defined in config file so that we can automatically look at what type of development uses how much resource.

my expecting scenarios:
- if user follows branch rule: pr-labeler attaches one of expected labels
- if user, by accident, didn't follow branch rule:
  1. CI fails due to nothing is matched
  2. user manually assign one of expected labels to PR