### PR TITLE
Read config from base.ref when PR from forked repo

### DIFF
--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -103,6 +103,22 @@ describe('pr-labeler-action', () => {
 
     await action(new MockContext(pullRequestOpenedFixture({ ref: 'hello_world' })));
   });
+
+  it('adds the "fix" label for "fix/510-logging" branch from forked repo', async () => {
+    nock('https://api.github.com')
+        .get('/repos/Codertocat/Hello-World/contents/.github%2Fpr-labeler.yml?ref=main')
+        .reply(200, configFixture())
+        .post('/repos/Codertocat/Hello-World/issues/1/labels', (body) => {
+          expect(body).toMatchObject({
+            labels: ['fix'],
+          });
+          return true;
+        })
+        .reply(200);
+
+    await action(new MockContext(pullRequestOpenedFixtureFromFork({ ref: 'fix/510-logging' })));
+    expect.assertions(1);
+  });
 });
 
 class MockContext extends Context {
@@ -145,6 +161,32 @@ function pullRequestOpenedFixture({ ref }: { ref: string }) {
         ref,
         repo: {
           full_name: 'Codertocat/Hello-World',
+        }
+      },
+      base: {
+        ref: 'main',
+        repo: {
+          full_name: 'Codertocat/Hello-World',
+        }
+      },
+    },
+    repository: {
+      name: 'Hello-World',
+      owner: {
+        login: 'Codertocat',
+      },
+    },
+  };
+}
+
+function pullRequestOpenedFixtureFromFork({ ref }: { ref: string }) {
+  return {
+    pull_request: {
+      number: 1,
+      head: {
+        ref,
+        repo: {
+          full_name: 'forked/Hello-World',
         }
       },
       base: {

--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -143,6 +143,15 @@ function pullRequestOpenedFixture({ ref }: { ref: string }) {
       number: 1,
       head: {
         ref,
+        repo: {
+          full_name: 'Codertocat/Hello-World',
+        }
+      },
+      base: {
+        ref: 'main',
+        repo: {
+          full_name: 'Codertocat/Hello-World',
+        }
       },
     },
     repository: {

--- a/src/action.ts
+++ b/src/action.ts
@@ -23,7 +23,7 @@ async function action(context: Context = github.context) {
     }
 
     let readConfigRef: string;
-    if (context.payload.pull_request.head.full_name === context.payload.pull_request.base.full_name) {
+    if (context.payload.pull_request.head.repo.full_name === context.payload.pull_request.base.repo.full_name) {
       readConfigRef = context.payload.pull_request.head.ref;
     } else {
       console.log("This pull request is from the forked repository. So read config from base.ref.")

--- a/src/action.ts
+++ b/src/action.ts
@@ -22,9 +22,17 @@ async function action(context: Context = github.context) {
       );
     }
 
-    const ref: string = context.payload.pull_request.head.ref;
-    const config = await getConfig(octokit, configPath, context.repo, ref, defaultConfig);
-    const labelsToAdd = getLabelsToAdd(config, ref);
+    let readConfigRef: string;
+    if (context.payload.pull_request.head.full_name === context.payload.pull_request.base.full_name) {
+      readConfigRef = context.payload.pull_request.head.ref;
+    } else {
+      console.log("This pull request is from the forked repository. So read config from base.ref.")
+      readConfigRef = context.payload.pull_request.base.ref;
+    }
+
+    const config = await getConfig(octokit, configPath, context.repo, readConfigRef, defaultConfig);
+    const headRef: string = context.payload.pull_request.head.ref;
+    const labelsToAdd = getLabelsToAdd(config, headRef);
 
     if (labelsToAdd.length > 0) {
       await octokit.issues.addLabels({

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -29,8 +29,9 @@ export default async function getConfig(
 
     throw new Error(`${path} does not point to a config file`);
   } catch (error: any) {
+    console.log(`Config file not found. owner=${owner}, repo=${repo}, path=${path}, ref=${ref}.`);
     if (error.status === 404) {
-      // TODO: add log
+      console.log(`Using default config.`);
       return defaultConfig;
     }
 


### PR DESCRIPTION
### Changes
- Using `base.ref` in read config file when pull request from forked repo
- Add test
- Add logging

### Reason
- When pull request from forked repo, `head.ref` is fork-repo's ref. It does not exist in base-repo.

refs #25